### PR TITLE
fix: resolve ICE socket when selected pair is unavailable and improve ice4j 1.0 compatibility

### DIFF
--- a/client/src/main/java/io/github/springstudent/dekstop/client/p2p/P2pSessionManager.java
+++ b/client/src/main/java/io/github/springstudent/dekstop/client/p2p/P2pSessionManager.java
@@ -10,12 +10,15 @@ import java.io.*;
 import java.lang.reflect.Method;
 import java.net.DatagramPacket;
 import java.net.DatagramSocket;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
@@ -31,6 +34,7 @@ public class P2pSessionManager {
     private volatile String token;
     private volatile long expireAt;
     private volatile long negotiationStartedAt;
+    private volatile ScheduledFuture<?> readyProbeFuture;
     private final AtomicLong p2pSuccess = new AtomicLong();
     private final AtomicLong fallbackCount = new AtomicLong();
     private final AtomicLong firstFrameLatencyMs = new AtomicLong(-1);
@@ -45,6 +49,7 @@ public class P2pSessionManager {
         this.token = result.getToken();
         this.expireAt = result.getExpireAt();
         this.negotiationStartedAt = System.currentTimeMillis();
+        cancelReadyProbe();
         this.state = P2pState.P2P_NEGOTIATING;
         this.ice4jTransport = Ice4jTransport.create(this::handleDirectInboundCmd);
         if (this.ice4jTransport == null) {
@@ -52,6 +57,7 @@ public class P2pSessionManager {
             return;
         }
         sendOffer(channel);
+        scheduleReadyProbe();
         scheduler.schedule(new Runnable() {
             @Override
             public void run() {
@@ -72,6 +78,7 @@ public class P2pSessionManager {
                 sendAnswer(channel);
                 if (ice4jTransport.startConnectivityChecks()) {
                     markP2pActiveIfReady();
+                    scheduleReadyProbe();
                 }
             } else {
                 fallback("apply remote offer failed");
@@ -80,6 +87,7 @@ public class P2pSessionManager {
             CmdP2pAnswer answer = (CmdP2pAnswer) cmd;
             if (ice4jTransport.applyRemoteDescription(answer.getSdp()) && ice4jTransport.startConnectivityChecks()) {
                 markP2pActiveIfReady();
+                scheduleReadyProbe();
             } else {
                 fallback("apply remote answer failed");
             }
@@ -120,6 +128,29 @@ public class P2pSessionManager {
         }
     }
 
+    private synchronized void scheduleReadyProbe() {
+        if (readyProbeFuture != null && !readyProbeFuture.isCancelled()) {
+            return;
+        }
+        readyProbeFuture = scheduler.scheduleAtFixedRate(new Runnable() {
+            @Override
+            public void run() {
+                if (state != P2pState.P2P_NEGOTIATING) {
+                    cancelReadyProbe();
+                    return;
+                }
+                markP2pActiveIfReady();
+            }
+        }, 100, 200, TimeUnit.MILLISECONDS);
+    }
+
+    private synchronized void cancelReadyProbe() {
+        if (readyProbeFuture != null) {
+            readyProbeFuture.cancel(false);
+            readyProbeFuture = null;
+        }
+    }
+
     private void handleDirectInboundCmd(Cmd cmd) {
         markP2pActive();
         if (directCmdConsumer != null) {
@@ -130,6 +161,7 @@ public class P2pSessionManager {
     private synchronized void markP2pActive() {
         if (state != P2pState.P2P_ACTIVE) {
             state = P2pState.P2P_ACTIVE;
+            cancelReadyProbe();
             p2pSuccess.incrementAndGet();
             if (firstFrameLatencyMs.get() < 0) {
                 firstFrameLatencyMs.set(System.currentTimeMillis() - negotiationStartedAt);
@@ -142,6 +174,7 @@ public class P2pSessionManager {
             return;
         }
         state = P2pState.RELAY_FALLBACK;
+        cancelReadyProbe();
         fallbackCount.incrementAndGet();
         Log.warn("fallback to relay: " + reason);
     }
@@ -218,6 +251,7 @@ public class P2pSessionManager {
         private final Object component;
         private final Consumer<Cmd> inboundConsumer;
         private volatile DatagramSocket selectedSocket;
+        private volatile InetSocketAddress selectedRemoteAddress;
 
         private Ice4jTransport(Object agent, Object stream, Object component, Consumer<Cmd> inboundConsumer) {
             this.agent = agent;
@@ -235,7 +269,8 @@ public class P2pSessionManager {
                 Class<?> transportClass = Class.forName("org.ice4j.Transport");
                 Object udp = Enum.valueOf((Class<Enum>) transportClass, "UDP");
 
-                Object component = invoke(agent, "createComponent", new Class[]{Class.forName("org.ice4j.ice.IceMediaStream"), transportClass, int.class, int.class, int.class}, stream, udp, 40000, 45000, 50000);
+                // ice4j expects (preferredPort, minPort, maxPort). Keep preferred within range for 1.x compatibility.
+                Object component = invoke(agent, "createComponent", new Class[]{Class.forName("org.ice4j.ice.IceMediaStream"), transportClass, int.class, int.class, int.class}, stream, udp, 45000, 40000, 50000);
 
                 Ice4jTransport transport = new Ice4jTransport(agent, stream, component, inboundConsumer);
                 transport.attachStateListener();
@@ -248,8 +283,8 @@ public class P2pSessionManager {
 
         String localDescription() {
             try {
-                String ufrag = String.valueOf(invoke(agent, "getLocalUfrag", new Class[]{}));
-                String pwd = String.valueOf(invoke(agent, "getLocalPassword", new Class[]{}));
+                String ufrag = String.valueOf(invokeNoArgAny("getLocalUfrag"));
+                String pwd = String.valueOf(invokeNoArgAny("getLocalPassword"));
                 StringBuilder sb = new StringBuilder();
                 sb.append("ufrag=").append(ufrag).append("\n");
                 sb.append("pwd=").append(pwd).append("\n");
@@ -295,8 +330,9 @@ public class P2pSessionManager {
                 if (remoteUfrag == null || remotePwd == null) {
                     return false;
                 }
-                invoke(agent, "setRemoteUfrag", new Class[]{Class.forName("org.ice4j.ice.IceMediaStream"), String.class}, stream, remoteUfrag);
-                invoke(agent, "setRemotePassword", new Class[]{Class.forName("org.ice4j.ice.IceMediaStream"), String.class}, stream, remotePwd);
+                if (!setRemoteCredential("setRemoteUfrag", remoteUfrag) || !setRemoteCredential("setRemotePassword", remotePwd)) {
+                    return false;
+                }
                 for (String c : candidateLines) {
                     addRemoteCandidate(c);
                 }
@@ -312,15 +348,69 @@ public class P2pSessionManager {
                 return false;
             }
             try {
-                // ice4j candidate parsing APIs differ by versions; best-effort use parser when available.
-                Class<?> parser = Class.forName("org.ice4j.ice.sdp.CandidateAttribute");
-                Object parsed = invokeStatic(parser, "parse", new Class[]{String.class}, candidateLine);
-                if (parsed != null) {
-                    invoke(component, "addRemoteCandidate", new Class[]{Class.forName("org.ice4j.ice.RemoteCandidate")}, parsed);
+                Object remoteCandidate = parseRemoteCandidate(candidateLine);
+                if (remoteCandidate == null) {
+                    return false;
+                }
+                if (invokeAddRemoteCandidate(remoteCandidate)) {
                     return true;
                 }
             } catch (Exception ignored) {
                 // fall through for compatibility
+            }
+            return false;
+        }
+
+        private Object parseRemoteCandidate(String candidateLine) {
+            try {
+                Class<?> parser = Class.forName("org.ice4j.ice.sdp.CandidateAttribute");
+                Object parsed = invokeStatic(parser, "parse", new Class[]{String.class}, candidateLine);
+                if (parsed == null) {
+                    return null;
+                }
+                try {
+                    Class<?> remoteCandidateClass = Class.forName("org.ice4j.ice.RemoteCandidate");
+                    if (remoteCandidateClass.isInstance(parsed)) {
+                        return parsed;
+                    }
+                } catch (Exception ignored) {
+                    // ignore and continue
+                }
+                Object candidateObj = invokeIfExistsReturning(parsed, "getCandidate", new Class[]{});
+                if (candidateObj != null) {
+                    return candidateObj;
+                }
+                return parsed;
+            } catch (Exception e) {
+                Log.warn("parse remote candidate failed");
+                return null;
+            }
+        }
+
+        private boolean invokeAddRemoteCandidate(Object remoteCandidate) {
+            try {
+                Class<?> remoteCandidateClass = Class.forName("org.ice4j.ice.RemoteCandidate");
+                if (remoteCandidateClass.isInstance(remoteCandidate)
+                        && invokeIfExists(component, "addRemoteCandidate", new Class[]{remoteCandidateClass}, remoteCandidate)) {
+                    return true;
+                }
+            } catch (Exception ignored) {
+                // try generic reflection fallback below
+            }
+            for (Method m : component.getClass().getMethods()) {
+                if (!"addRemoteCandidate".equals(m.getName()) || m.getParameterTypes().length != 1) {
+                    continue;
+                }
+                Class<?> param = m.getParameterTypes()[0];
+                if (remoteCandidate != null && param.isAssignableFrom(remoteCandidate.getClass())) {
+                    try {
+                        m.setAccessible(true);
+                        m.invoke(component, remoteCandidate);
+                        return true;
+                    } catch (Exception ignored) {
+                        // keep trying other overloads
+                    }
+                }
             }
             return false;
         }
@@ -346,11 +436,17 @@ public class P2pSessionManager {
                 return false;
             }
             try {
-                java.net.SocketAddress remote = selectedSocket.getRemoteSocketAddress();
-                if (!(remote instanceof java.net.InetSocketAddress)) {
+                SocketAddress remote = selectedSocket.getRemoteSocketAddress();
+                InetSocketAddress target = null;
+                if (remote instanceof InetSocketAddress) {
+                    target = (InetSocketAddress) remote;
+                } else if (selectedRemoteAddress != null) {
+                    target = selectedRemoteAddress;
+                }
+                if (target == null) {
                     return false;
                 }
-                selectedSocket.send(new DatagramPacket(payload, payload.length, (java.net.InetSocketAddress) remote));
+                selectedSocket.send(new DatagramPacket(payload, payload.length, target));
                 return true;
             } catch (Exception e) {
                 Log.warn("ice send failed", e);
@@ -360,20 +456,16 @@ public class P2pSessionManager {
 
         private void attachStateListener() {
             try {
-                Class<?> pcl = Class.forName("java.beans.PropertyChangeListener");
-                Object listener = java.lang.reflect.Proxy.newProxyInstance(
-                        pcl.getClassLoader(), new Class[]{pcl},
-                        (proxy, method, args) -> {
-                            if ("propertyChange".equals(method.getName())) {
-                                ensureSelectedSocket();
-                                if (selectedSocket != null) {
-                                    startReceiverIfNeeded();
-                                }
-                            }
-                            return null;
+                java.beans.PropertyChangeListener listener = new java.beans.PropertyChangeListener() {
+                    @Override
+                    public void propertyChange(java.beans.PropertyChangeEvent evt) {
+                        ensureSelectedSocket();
+                        if (selectedSocket != null) {
+                            startReceiverIfNeeded();
                         }
-                );
-                invoke(agent, "addStateChangeListener", new Class[]{pcl}, listener);
+                    }
+                };
+                invoke(agent, "addStateChangeListener", new Class[]{java.beans.PropertyChangeListener.class}, listener);
             } catch (Exception e) {
                 Log.warn("attach state listener failed", e);
             }
@@ -420,17 +512,126 @@ public class P2pSessionManager {
                 return;
             }
             try {
-                Object pair = invoke(component, "getSelectedPair", new Class[]{});
+                Object pair = invokeIfExistsReturning(component, "getSelectedPair", new Class[]{});
                 if (pair == null) {
-                    return;
+                    pair = invokeIfExistsReturning(stream, "getSelectedPair", new Class[]{});
                 }
-                Object wrapper = invoke(pair, "getIceSocketWrapper", new Class[]{});
-                Object socket = invoke(wrapper, "getUDPSocket", new Class[]{});
-                if (socket instanceof DatagramSocket) {
-                    selectedSocket = (DatagramSocket) socket;
+                if (pair != null) {
+                    if (extractSocketFromPair(pair)) {
+                        return;
+                    }
+                }
+
+                Object wrapper = invokeIfExistsReturning(component, "getComponentSocket", new Class[]{});
+                if (wrapper != null) {
+                    Object socket = invokeIfExistsReturning(wrapper, "getUDPSocket", new Class[]{});
+                    if (socket instanceof DatagramSocket) {
+                        selectedSocket = (DatagramSocket) socket;
+                        return;
+                    }
                 }
             } catch (Exception e) {
                 Log.debug("selected socket not ready yet");
+            }
+        }
+
+        private boolean extractSocketFromPair(Object pair) {
+            Object wrapper = invokeIfExistsReturning(pair, "getIceSocketWrapper", new Class[]{});
+            if (wrapper == null) {
+                return false;
+            }
+            Object socket = invokeIfExistsReturning(wrapper, "getUDPSocket", new Class[]{});
+            if (!(socket instanceof DatagramSocket)) {
+                return false;
+            }
+            selectedSocket = (DatagramSocket) socket;
+            Object remoteCandidate = invokeIfExistsReturning(pair, "getRemoteCandidate", new Class[]{});
+            if (remoteCandidate != null) {
+                Object ta = invokeIfExistsReturning(remoteCandidate, "getTransportAddress", new Class[]{});
+                InetSocketAddress addr = toInetSocketAddress(ta);
+                if (addr != null) {
+                    selectedRemoteAddress = addr;
+                }
+            }
+            return true;
+        }
+
+        private InetSocketAddress toInetSocketAddress(Object transportAddress) {
+            if (transportAddress == null) {
+                return null;
+            }
+            if (transportAddress instanceof InetSocketAddress) {
+                return (InetSocketAddress) transportAddress;
+            }
+            try {
+                Object host = invokeIfExistsReturning(transportAddress, "getHostAddress", new Class[]{});
+                Object port = invokeIfExistsReturning(transportAddress, "getPort", new Class[]{});
+                if (host != null && port instanceof Integer) {
+                    return new InetSocketAddress(String.valueOf(host), (Integer) port);
+                }
+            } catch (Exception ignored) {
+                // best effort
+            }
+            return null;
+        }
+
+        private Object invokeNoArgAny(String methodName) throws Exception {
+            if (hasMethod(agent, methodName, new Class[]{})) {
+                return invoke(agent, methodName, new Class[]{});
+            }
+            if (hasMethod(stream, methodName, new Class[]{})) {
+                return invoke(stream, methodName, new Class[]{});
+            }
+            throw new NoSuchMethodException(methodName);
+        }
+
+        private boolean setRemoteCredential(String methodName, String value) {
+            try {
+                Class<?> iceStreamClass = Class.forName("org.ice4j.ice.IceMediaStream");
+                if (invokeIfExists(agent, methodName, new Class[]{iceStreamClass, String.class}, stream, value)) {
+                    return true;
+                }
+                if (invokeIfExists(agent, methodName, new Class[]{String.class}, value)) {
+                    return true;
+                }
+                if (invokeIfExists(stream, methodName, new Class[]{String.class}, value)) {
+                    return true;
+                }
+            } catch (Exception e) {
+                Log.warn("set remote credential failed: " + methodName, e);
+                return false;
+            }
+            Log.warn("set remote credential method missing: " + methodName);
+            return false;
+        }
+
+        private static boolean hasMethod(Object target, String name, Class<?>[] paramTypes) {
+            try {
+                target.getClass().getMethod(name, paramTypes);
+                return true;
+            } catch (NoSuchMethodException e) {
+                return false;
+            }
+        }
+
+        private static Object invokeIfExistsReturning(Object target, String name, Class<?>[] paramTypes, Object... args) {
+            try {
+                Method m = target.getClass().getMethod(name, paramTypes);
+                m.setAccessible(true);
+                return m.invoke(target, args);
+            } catch (Exception e) {
+                return null;
+            }
+        }
+
+        private static boolean invokeIfExists(Object target, String name, Class<?>[] paramTypes, Object... args) throws Exception {
+            try {
+                Method m = target.getClass().getMethod(name, paramTypes);
+                m.setAccessible(true);
+                m.invoke(target, args);
+                return true;
+            } catch (NoSuchMethodException e) {
+                return false;
             }
         }
 

--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
             <dependency>
                 <groupId>org.jitsi</groupId>
                 <artifactId>ice4j</artifactId>
-                <version>3.0-57-gf4e5cfd</version>
+                <version>1.0</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
### Motivation
- ICE direct P2P setup was failing when `getSelectedPair()` remained `null`, preventing extraction of the UDP socket and remote address and causing negotiation timeouts.
- The code needed to be more resilient across ice4j API shapes (1.0 vs newer) for candidate parsing/injection and credential setting.
- Readiness detection was too coarse, so a lightweight probe was added to mark P2P active sooner when a socket becomes available.

### Description
- Updated `Ice4jTransport.ensureSelectedSocket()` to try `component.getSelectedPair()`, then `stream.getSelectedPair()`, and finally `component.getComponentSocket()` as a fallback to locate the UDP socket. 
- Added `extractSocketFromPair(...)` and `toInetSocketAddress(...)` to extract and cache both the `DatagramSocket` and a remote `InetSocketAddress` when available, and added a `selectedRemoteAddress` field used when `DatagramSocket#getRemoteSocketAddress()` is empty.
- Reworked remote candidate handling with `parseRemoteCandidate(...)` to use `org.ice4j.ice.sdp.CandidateAttribute.parse`, and `invokeAddRemoteCandidate(...)` which tries typed injection and then reflective overload matching for wide compatibility; also added `setRemoteCredential(...)`, `invokeNoArgAny(...)`, and helper reflection utilities (`invokeIfExistsReturning`, `invokeIfExists`, `hasMethod`).
- Improved send/receive and state handling: `send(...)` will use the cached `selectedRemoteAddress` if the socket's remote address is not populated, state listener uses `java.beans.PropertyChangeListener`, and a readiness probe (`scheduleReadyProbe` / `cancelReadyProbe`) periodically calls `markP2pActiveIfReady()` while negotiating.
- Adjusted `createComponent` port argument ordering for better ice4j 1.x behavior and updated `pom.xml` to depend on `org.jitsi:ice4j:1.0`.

### Testing
- Attempted `mvn -pl client -am -DskipTests compile` to validate compilation, but the build failed because Maven Central returned HTTP 403 when resolving `org.springframework.boot:spring-boot-dependencies`, so a full compile could not be verified in this environment.
- No automated unit tests were executed in this environment due to the dependency resolution failure.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698c8eea5ac88321b851a10186ae1a11)