### PR TITLE
config(pom.xml): Add explicit Maven compiler source and target properties

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,8 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
         <spring.boot.version>2.3.4.RELEASE</spring.boot.version>
         <fastjson.version>1.2.28</fastjson.version>
         <mysql.connector.version>8.0.16</mysql.connector.version>


### PR DESCRIPTION
> Related issue #17 

## 解决方案

在父 `pom.xml` 中显示指定 `maven.compiler.source` 和 `maven.compiler.target` 属性（版本 1.8）。

重新运行构建

```
openjdk version "17" 2021-09-14
OpenJDK Runtime Environment (build 17+35-2724)
OpenJDK 64-Bit Server VM (build 17+35-2724, mixed mode, sharing)
Apache Maven 3.6.1 (d66c9c0b3152b2e69ee9bac180bb8fcc8e6af555; 2019-04-05T03:00:29+08:00)
Maven home: /home/data/app/apache-maven-3.6.1
Java version: 1.8.0_412, vendor: Red Hat, Inc., runtime: /usr/lib/jvm/java-1.8.0-openjdk-1.8.0.412.b08-1.el7_9.x86_64/jre
Default locale: en_US, platform encoding: UTF-8
OS name: "linux", version: "3.10.0-693.2.2.el7.x86_64", arch: "amd64", family: "unix"
[INFO] Scanning for projects...
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Build Order:
[INFO] 
[INFO] remote-desktop-control                                             [pom]
[INFO] common                                                             [jar]
[INFO] server                                                             [jar]
[INFO] 
[INFO] -----------< io.github.springstudent:remote-desktop-control >-----------
[INFO] Building remote-desktop-control 1.0.0                              [1/3]
[INFO] --------------------------------[ pom ]---------------------------------
[INFO] 
[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ remote-desktop-control ---
[INFO] 
[INFO] -------------------< io.github.springstudent:common >-------------------
[INFO] Building common 1.0.0                                              [2/3]
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ common ---
[INFO] Deleting /home/data/app/remote-desktop-control/common/target
[INFO] 
[INFO] --- maven-resources-plugin:2.6:resources (default-resources) @ common ---
[INFO] Using 'UTF-8' encoding to copy filtered resources.
[INFO] skip non existing resourceDirectory /home/data/app/remote-desktop-control/common/src/main/resources
[INFO] 
[INFO] --- maven-compiler-plugin:3.1:compile (default-compile) @ common ---
[INFO] Changes detected - recompiling the module!
[INFO] Compiling 55 source files to /home/data/app/remote-desktop-control/common/target/classes
[INFO] 
[INFO] --- maven-resources-plugin:2.6:testResources (default-testResources) @ common ---
[INFO] Not copying test resources
[INFO] 
[INFO] --- maven-compiler-plugin:3.1:testCompile (default-testCompile) @ common ---
[INFO] Not compiling test sources
[INFO] 
[INFO] --- maven-surefire-plugin:2.12.4:test (default-test) @ common ---

...
...
...

[INFO] 
[INFO] --- maven-resources-plugin:2.6:resources (default-resources) @ server ---
[INFO] Using 'UTF-8' encoding to copy filtered resources.
[INFO] Copying 3 resources
[INFO] 
[INFO] --- maven-compiler-plugin:3.1:compile (default-compile) @ server ---
[INFO] Changes detected - recompiling the module!
[INFO] Compiling 29 source files to /home/data/app/remote-desktop-control/server/target/classes
[WARNING] /home/data/app/remote-desktop-control/server/src/main/java/io/github/springstudent/dekstop/server/netty/NettyServerHandler.java: /home/data/app/remote-desktop-control/server/src/main/java/io/github/springstudent/dekstop/server/netty/NettyServerHandler.java uses unchecked or unsafe operations.
[WARNING] /home/data/app/remote-desktop-control/server/src/main/java/io/github/springstudent/dekstop/server/netty/NettyServerHandler.java: Recompile with -Xlint:unchecked for details.
[INFO] 
[INFO] --- maven-resources-plugin:2.6:testResources (default-testResources) @ server ---
[INFO] Not copying test resources
[INFO] 
[INFO] --- maven-compiler-plugin:3.1:testCompile (default-testCompile) @ server ---
[INFO] Not compiling test sources
[INFO] 
[INFO] --- maven-surefire-plugin:2.12.4:test (default-test) @ server ---
[INFO] Tests are skipped.
[INFO] 
[INFO] --- maven-jar-plugin:2.4:jar (default-jar) @ server ---
[INFO] Building jar: /home/data/app/remote-desktop-control/server/target/server-1.0.0.jar
[INFO] 
[INFO] --- spring-boot-maven-plugin:2.3.4.RELEASE:repackage (default) @ server ---
[INFO] Replacing main artifact with repackaged archive
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for remote-desktop-control 1.0.0:
[INFO] 
[INFO] remote-desktop-control ............................. SUCCESS [  0.127 s]
[INFO] common ............................................. SUCCESS [  8.737 s]
[INFO] server ............................................. SUCCESS [ 42.169 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  51.439 s
[INFO] Finished at: 2026-04-20T11:56:56+08:00
[INFO] ------------------------------------------------------------------------
```