### PR TITLE
fix: sync RobotsClient robotPort to match RobotsServer default port

### DIFF
--- a/client/src/main/java/io/github/springstudent/dekstop/client/RemoteClient.java
+++ b/client/src/main/java/io/github/springstudent/dekstop/client/RemoteClient.java
@@ -211,7 +211,7 @@ public class RemoteClient extends RemoteFrame {
     }
 
     public static void main(String[] args) throws Exception {
-        int robotPort = 49152;
+        int robotPort = 55678;
         if (System.getProperty("robotPort") != null) {
             robotPort = Integer.parseInt(System.getProperty("robotPort"));
         }


### PR DESCRIPTION
## Summary
- Fix RobotsClient default robotPort (49152 -> 55678) to match RobotsServer default port
- This ensures RemoteClient can properly connect to local RobotsServer when running on Windows